### PR TITLE
Reducing webapp package size and doing install on CI server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ install:
   - npm install -g coveralls
   - npm install -g strongloop
   - cd client
+  # Loads all DEV and PROD dependencies since we need them.  Later we prune.
   - npm install
   # GitHub Token needed to avoid GitHub API Rate Limit Thresholds
   - jspm config registries.github.auth $JSPM_GITHUB_AUTH_TOKEN
@@ -27,13 +28,16 @@ install:
 script:
   - cd client
   - gulp build
+  # Prune the node_modules since they are mostly DEV and it increases the package ~150MB
+  - npm prune --production
   - cd ..
+  # Pruning is embedded in this call for the root directory
   - slc build --install
 before_deploy:
   # This section runs PER PROVIDER listed in the deploy section.  This means
   # idempotent behavior for all these steps is required in order to avoid
   # insidious bugs and unwanted side-effects.
-  - zip -rq heimdall-webapp-1.0.0.zip * -x 'node_modules/*' -x 'client/node_modules/*'
+  - zip -rq heimdall-webapp-1.0.0.zip *
   - mkdir -p dpl_cd_upload
   - mv heimdall-webapp-1.0.0.zip dpl_cd_upload/heimdall-webapp-1.0.0.zip
 deploy:

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -4,19 +4,10 @@ curl --silent --location https://rpm.nodesource.com/setup_4.x | bash -
 yum -y install nodejs
 npm install -g npm
 npm install -g strong-pm
-npm install -g strongloop
-
-# Install Aurelia UI Dependencies.
-# We did not do this on the CI server because the bundle is ~300MB.
-# We will need to figure out a better way to handle this.
-cd client
-npm install -g gulp
-npm install
-gulp build
 
 # Install and Pack the Node/Loopback Dependencies
 # Unable to build and pack since CodeDeploy expects appspec.yml to be at the
 # root of the package and packing has an intermediate folder that disrupts.
-cd ..
-slc build --npm
+npm install -g strongloop
+slc build --pack
 sl-pm-install --upstart=0.6 --force


### PR DESCRIPTION
doing all the installing on the CI server with the exception of packing the entire package which is for the deployment server.  Also installing of node modules is now done with 'pruning' to reduce the size of the package by 90%