### PR TITLE
Bug Project-Heimdall/home#14 Project-Heimdall/home#3 Adjusting search que…

### DIFF
--- a/server/datasources.json
+++ b/server/datasources.json
@@ -32,11 +32,10 @@
             "multi_match" : {
               "query":      "x",
               "type":       "cross_fields",
-              "fields":     ["project_name","project_description"],
+              "fields":     ["project_name^3","project_description^2", "content"],
               "operator":   "or"
             }
-          },
-          "sort" : { "rank" : { "order" : "desc" }}
+          }
         }
       },
       "functions": {


### PR DESCRIPTION
…ry params and weight to properly return data when searching in content.

For example, searching "platform" did not return cognition even though platform was a word in the cognition readme. This works not by adjusting some of the ES query parameters.